### PR TITLE
Remove duplicate package colortbl

### DIFF
--- a/config/config.tex
+++ b/config/config.tex
@@ -9,7 +9,6 @@
 \usepackage{colortbl} % Add colour to LaTeX tables
 \usepackage{caption}
 \usepackage[export]{adjustbox}
-\usepackage{colortbl}
 \usepackage{pgfplots}
 
 % Color Options


### PR DESCRIPTION
# Description

Not much to review. I removed line 12 from config.tex because the colortbl package is already used in line 9.

## Type of Change

- [x] Typo fix (Changes that fix spelling errors)

# Checklist:

- [x] I have performed a self-review of my own changes
- [x] I have made sure that any changed LaTeX files compile properly
- [x] I have assigned at least one reviewer
