### PR TITLE
Add first version of Fork Theory slides

### DIFF
--- a/assets/bib/refs.bib
+++ b/assets/bib/refs.bib
@@ -36,3 +36,9 @@
   year={1998},
   publisher={Elsevier}
   }
+
+@article{schar2020blockchain,
+  title={Blockchain Forks: A Formal Classification Framework and Persistency Analysis},
+  author={Schär, Fabian},
+  year={2020}
+  }

--- a/assets/figures/forced-fork.tex
+++ b/assets/figures/forced-fork.tex
@@ -1,0 +1,7 @@
+%%% Figure from: Schär, Fabian. "Blockchain Forks: A Formal Classification Framework and Persistency Analysis." (2020).
+
+\begin{tikzpicture}[domain=0:8,scale=0.9, every node/.style={scale=1}]
+  \filldraw[draw=black, fill=white] (0.9,-0.9) circle (32pt) node[color=black]{\footnotesize{$S_{old}$}};
+  \filldraw[draw=black,fill=blue!20] (-0.4,0.4) circle (32pt) node[color=black]{\footnotesize{$S_{new}$}};
+  \filldraw[draw=black, fill=white, opacity=0.5] (0.9,-0.9) circle (32pt) node[color=black]{\footnotesize{$S_{old}$}};
+\end{tikzpicture}

--- a/assets/figures/fork-persistency.tex
+++ b/assets/figures/fork-persistency.tex
@@ -1,0 +1,387 @@
+%%% Figures from: Schär, Fabian. "Blockchain Forks: A Formal Classification Framework and Persistency Analysis." (2020).
+
+\begin{table*}[h!]
+\center
+  \begin{tabular}{ccc}
+  \hline \hline
+     & $S_{new}$ dominant ($r_{new}>r_{old}$) & $S_{old}$ dominant ($r_{new}<r_{old}$)\\ \cline{2-3}
+     &&\\
+    Soft fork & %($S_{new} \subset S_{old}$)&
+\begin{tikzpicture}[domain=1:10,scale=0.5, every node/.style={scale=0.5}]
+\coordinate (o1) at (1,1);
+\coordinate (o2) at (2,1);
+\coordinate (o3) at (3,1);
+\coordinate (o4) at (4,1);
+\coordinate (o5) at (5,1);
+\coordinate (o6) at (6,1);
+\coordinate (o7) at (7,1);
+\coordinate (o8) at (8,1);
+\coordinate (o9) at (9,1);
+\coordinate (o10) at (10,1);
+\coordinate (n1) at (1,0.25);
+\coordinate (n2) at (2,0.25);
+\coordinate (n3) at (3,0.25);
+\coordinate (n4) at (4,0.25);
+\coordinate (n5) at (5,0.25);
+\coordinate (n6) at (6,0.25);
+\coordinate (n7) at (7,0.25);
+\coordinate (n8) at (8,0.25);
+\coordinate (n9) at (9,0.25);
+\coordinate (n10) at (10,0.25);
+
+  \draw[] (o1) to[] (o2) to[] (o3) to[] (o4);
+  \draw[] (o3) to[] (n4) to[] (n5) to[] (n6) to[] (n7) to[] (n8) to[] (n9);
+  \draw[color=black] (n6) to[] (o7);
+  %\draw[color=black,densely dashed] (o4) to[] (o5);
+  %\draw[color=black,densely dashed] (o7) to[] (o8);
+  \draw[color=black,thick, dotted, ->] (n9) to[] (n10);
+
+  %\filldraw[draw=black,fill=white] (o1) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o2) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o3) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o4) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o5) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o6) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o7) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o8) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o9) circle (5pt);
+  \node (rect) at (o1) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o2) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o3) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o4) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (o5) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (o6) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o7) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (o8) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (o9) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\filldraw[draw=black,fill=blue] (n4) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n5) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n6) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n7) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n8) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n9) circle (5pt);
+  %\node (rect) at (n1) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (n2) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (n3) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n4) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n5) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n6) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n7) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n8) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n9) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+\end{tikzpicture}
+    &
+\begin{tikzpicture}[domain=1:10,scale=0.5, every node/.style={scale=0.5}]
+\coordinate (o1) at (1,1);
+\coordinate (o2) at (2,1);
+\coordinate (o3) at (3,1);
+\coordinate (o4) at (4,1);
+\coordinate (o5) at (5,1);
+\coordinate (o6) at (6,1);
+\coordinate (o7) at (7,1);
+\coordinate (o8) at (8,1);
+\coordinate (o9) at (9,1);
+\coordinate (o10) at (10,1);
+\coordinate (n1) at (1,0.25);
+\coordinate (n2) at (2,0.25);
+\coordinate (n3) at (3,0.25);
+\coordinate (n4) at (4,0.25);
+\coordinate (n5) at (5,0.25);
+\coordinate (n6) at (6,0.25);
+\coordinate (n7) at (7,0.25);
+\coordinate (n8) at (8,0.25);
+\coordinate (n9) at (9,0.25);
+\coordinate (n10) at (10,0.25);
+
+  \draw[color=black] (o1) to[] (o2) to[] (o3) to[] (o4) to (o5) to (o6) to (o7) to (o8) to (o9);
+  \draw[color=black] (o3) to[] (n4) to[] (n5) to[] (n6) to[] (n7);
+  \draw[color=black,thick, dotted, ->] (o9) to[] (o10);
+  \draw[color=black,thick, dotted, ->] (n7) to[] (n8);
+
+  %\filldraw[draw=black,fill=white] (o1) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o2) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o3) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o4) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o5) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o6) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o7) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o8) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o9) circle (5pt);
+  \node (rect) at (o1) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o2) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o3) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o4) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o5) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o6) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o7) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o8) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o9) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\filldraw[draw=black,fill=blue] (n4) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n5) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n6) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n7) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n8) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n9) circle (5pt);
+  %\node (rect) at (n1) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (n2) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (n3) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n4) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n5) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n6) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n7) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (n8) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (n9) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+\end{tikzpicture}
+    \\
+    &&\\
+    Hard fork &
+    \begin{tikzpicture}[domain=1:10,scale=0.5, every node/.style={scale=0.5}]
+\coordinate (o1) at (1,1);
+\coordinate (o2) at (2,1);
+\coordinate (o3) at (3,1);
+\coordinate (o4) at (4,1);
+\coordinate (o5) at (5,1);
+\coordinate (o6) at (6,1);
+\coordinate (o7) at (7,1);
+\coordinate (o8) at (8,1);
+\coordinate (o9) at (9,1);
+\coordinate (o10) at (10,1);
+\coordinate (n1) at (1,0.25);
+\coordinate (n2) at (2,0.25);
+\coordinate (n3) at (3,0.25);
+\coordinate (n4) at (4,0.25);
+\coordinate (n5) at (5,0.25);
+\coordinate (n6) at (6,0.25);
+\coordinate (n7) at (7,0.25);
+\coordinate (n8) at (8,0.25);
+\coordinate (n9) at (9,0.25);
+\coordinate (n10) at (10,0.25);
+
+  \draw[color=black] (o1) to[] (o2) to[] (o3) to[] (o4) to (o5) to (o6) to (o7);
+  \draw[color=black] (o3) to[] (n4) to[] (n5) to[] (n6) to[] (n7) to[] (n8) to[] (n9);
+  \draw[color=black,thick, dotted, ->] (o7) to[] (o8);
+  \draw[color=black,thick, dotted, ->] (n9) to[] (n10);
+
+  %\filldraw[draw=black,fill=white] (o1) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o2) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o3) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o4) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o5) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o6) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o7) circle (5pt);
+  \node (rect) at (o1) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o2) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o3) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o4) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o5) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o6) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o7) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (o8) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (o9) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\filldraw[draw=black,fill=white] (o8) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o9) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n4) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n5) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n6) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n7) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n8) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n9) circle (5pt);
+  %\node (rect) at (n1) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (n2) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (n3) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n4) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n5) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n6) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n7) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n8) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n9) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+\end{tikzpicture}
+  &
+\begin{tikzpicture}[domain=1:10,scale=0.5, every node/.style={scale=0.5}]
+\coordinate (o1) at (1,1);
+\coordinate (o2) at (2,1);
+\coordinate (o3) at (3,1);
+\coordinate (o4) at (4,1);
+\coordinate (o5) at (5,1);
+\coordinate (o6) at (6,1);
+\coordinate (o7) at (7,1);
+\coordinate (o8) at (8,1);
+\coordinate (o9) at (9,1);
+\coordinate (o10) at (10,1);
+\coordinate (n1) at (1,0.25);
+\coordinate (n2) at (2,0.25);
+\coordinate (n3) at (3,0.25);
+\coordinate (n4) at (4,0.25);
+\coordinate (n5) at (5,0.25);
+\coordinate (n6) at (6,0.25);
+\coordinate (n7) at (7,0.25);
+\coordinate (n8) at (8,0.25);
+\coordinate (n9) at (9,0.25);
+\coordinate (n10) at (10,0.25);
+
+  \draw[color=black] (o1) to[] (o2) to[] (o3) to[] (o4) to (o5) to (o6) to (o7) to (o8) to (o9);
+  \draw[color=black] (o3) to[] (n4);
+  \draw[color=black] (o6) to[] (n7);
+  \draw[color=black,thick, dotted, ->] (o9) to[] (o10);
+  %\draw[color=black, dashed] (n4) to[] (n5);
+  %\draw[color=black, dashed] (n7) to[] (n8);
+
+  %\filldraw[draw=black,fill=white] (o1) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o2) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o3) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o4) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o5) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o6) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o7) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o8) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o9) circle (5pt);
+  \node (rect) at (o1) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o2) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o3) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o4) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o5) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o6) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o7) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o8) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o9) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\filldraw[draw=black,fill=blue] (n4) circle (5pt);
+  \node (rect) at (n4) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\filldraw[draw=black,fill=blue] (n5) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n6) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n7) circle (5pt);
+  \node (rect) at (n7) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\filldraw[draw=black,fill=blue] (n8) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n9) circle (5pt);
+\end{tikzpicture}
+
+   \\
+    &&\\
+    Forced fork &
+    \begin{tikzpicture}[domain=1:10,scale=0.5, every node/.style={scale=0.5}]
+\coordinate (o1) at (1,1);
+\coordinate (o2) at (2,1);
+\coordinate (o3) at (3,1);
+\coordinate (o4) at (4,1);
+\coordinate (o5) at (5,1);
+\coordinate (o6) at (6,1);
+\coordinate (o7) at (7,1);
+\coordinate (o8) at (8,1);
+\coordinate (o9) at (9,1);
+\coordinate (o10) at (10,1);
+\coordinate (n1) at (1,0.25);
+\coordinate (n2) at (2,0.25);
+\coordinate (n3) at (3,0.25);
+\coordinate (n4) at (4,0.25);
+\coordinate (n5) at (5,0.25);
+\coordinate (n6) at (6,0.25);
+\coordinate (n7) at (7,0.25);
+\coordinate (n8) at (8,0.25);
+\coordinate (n9) at (9,0.25);
+\coordinate (n10) at (10,0.25);
+
+  \draw[color=black] (o1) to[] (o2) to[] (o3) to[] (o4) to (o5) to (o6) to (o7);
+  \draw[color=black] (o3) to[] (n4) to[] (n5) to[] (n6) to[] (n7) to[] (n8) to[] (n9);
+  \draw[color=black,thick, dotted, ->] (o7) to[] (o8);
+  \draw[color=black,thick, dotted, ->] (n9) to[] (n10);
+
+  %\filldraw[draw=black,fill=white] (o1) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o2) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o3) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o4) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o5) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o6) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o7) circle (5pt);
+  \node (rect) at (o1) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o2) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o3) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o4) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o5) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o6) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o7) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (o8) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (o9) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\filldraw[draw=black,fill=white] (o8) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o9) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n4) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n5) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n6) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n7) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n8) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n9) circle (5pt);
+  %\node (rect) at (n1) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (n2) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (n3) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n4) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n5) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n6) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n7) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n8) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n9) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+\end{tikzpicture}
+  &
+\begin{tikzpicture}[domain=1:10,scale=0.5, every node/.style={scale=0.5}]
+\coordinate (o1) at (1,1);
+\coordinate (o2) at (2,1);
+\coordinate (o3) at (3,1);
+\coordinate (o4) at (4,1);
+\coordinate (o5) at (5,1);
+\coordinate (o6) at (6,1);
+\coordinate (o7) at (7,1);
+\coordinate (o8) at (8,1);
+\coordinate (o9) at (9,1);
+\coordinate (o10) at (10,1);
+\coordinate (n1) at (1,0.25);
+\coordinate (n2) at (2,0.25);
+\coordinate (n3) at (3,0.25);
+\coordinate (n4) at (4,0.25);
+\coordinate (n5) at (5,0.25);
+\coordinate (n6) at (6,0.25);
+\coordinate (n7) at (7,0.25);
+\coordinate (n8) at (8,0.25);
+\coordinate (n9) at (9,0.25);
+\coordinate (n10) at (10,0.25);
+
+  \draw[color=black] (o1) to[] (o2) to[] (o3) to[] (o4) to (o5) to (o6) to (o7) to (o8) to (o9);
+  \draw[color=black] (o3) to[] (n4) to[] (n5) to[] (n6) to[] (n7);
+  \draw[color=black,thick, dotted, ->] (o9) to[] (o10);
+  \draw[color=black,thick, dotted, ->] (n7) to[] (n8);
+
+  %\filldraw[draw=black,fill=white] (o1) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o2) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o3) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o4) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o5) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o6) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o7) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o8) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o9) circle (5pt);
+  \node (rect) at (o1) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o2) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o3) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o4) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o5) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o6) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o7) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o8) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o9) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\filldraw[draw=black,fill=blue] (n4) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n5) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n6) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n7) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n8) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n9) circle (5pt);
+  %\node (rect) at (n1) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (n2) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (n3) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n4) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n5) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n6) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n7) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (n8) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (n9) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+\end{tikzpicture}
+
+\\
+&&\\ \hline \hline
+  \end{tabular}
+\end{table*}

--- a/assets/figures/fork-types.tex
+++ b/assets/figures/fork-types.tex
@@ -1,0 +1,387 @@
+%%% Figure from: Schär, Fabian. "Blockchain Forks: A Formal Classification Framework and Persistency Analysis." (2020). 
+
+\begin{table}[h!]
+\center
+  \begin{tabular}{ccc}
+  \hline \hline
+     & \scriptsize $S_{new}$ dominant ($r_{new}>r_{old}$) & \scriptsize $S_{old}$ dominant ($r_{new}<r_{old}$)\\ \cline{2-3}
+     &&\\
+    Soft fork & %($S_{new} \subset S_{old}$)&
+\begin{tikzpicture}[domain=1:10,scale=0.35, every node/.style={scale=0.35}]
+\coordinate (o1) at (1,1);
+\coordinate (o2) at (2,1);
+\coordinate (o3) at (3,1);
+\coordinate (o4) at (4,1);
+\coordinate (o5) at (5,1);
+\coordinate (o6) at (6,1);
+\coordinate (o7) at (7,1);
+\coordinate (o8) at (8,1);
+\coordinate (o9) at (9,1);
+\coordinate (o10) at (10,1);
+\coordinate (n1) at (1,0.25);
+\coordinate (n2) at (2,0.25);
+\coordinate (n3) at (3,0.25);
+\coordinate (n4) at (4,0.25);
+\coordinate (n5) at (5,0.25);
+\coordinate (n6) at (6,0.25);
+\coordinate (n7) at (7,0.25);
+\coordinate (n8) at (8,0.25);
+\coordinate (n9) at (9,0.25);
+\coordinate (n10) at (10,0.25);
+
+  \draw[] (o1) to[] (o2) to[] (o3) to[] (o4);
+  \draw[] (o3) to[] (n4) to[] (n5) to[] (n6) to[] (n7) to[] (n8) to[] (n9);
+  \draw[color=black] (n6) to[] (o7);
+  %\draw[color=black,densely dashed] (o4) to[] (o5);
+  %\draw[color=black,densely dashed] (o7) to[] (o8);
+  \draw[color=black,thick, dotted, ->] (n9) to[] (n10);
+
+  %\filldraw[draw=black,fill=white] (o1) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o2) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o3) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o4) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o5) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o6) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o7) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o8) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o9) circle (5pt);
+  \node (rect) at (o1) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o2) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o3) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o4) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (o5) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (o6) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o7) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (o8) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (o9) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\filldraw[draw=black,fill=blue] (n4) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n5) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n6) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n7) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n8) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n9) circle (5pt);
+  %\node (rect) at (n1) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (n2) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (n3) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n4) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n5) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n6) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n7) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n8) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n9) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+\end{tikzpicture}
+    &
+\begin{tikzpicture}[domain=1:10,scale=0.35, every node/.style={scale=0.35}]
+\coordinate (o1) at (1,1);
+\coordinate (o2) at (2,1);
+\coordinate (o3) at (3,1);
+\coordinate (o4) at (4,1);
+\coordinate (o5) at (5,1);
+\coordinate (o6) at (6,1);
+\coordinate (o7) at (7,1);
+\coordinate (o8) at (8,1);
+\coordinate (o9) at (9,1);
+\coordinate (o10) at (10,1);
+\coordinate (n1) at (1,0.25);
+\coordinate (n2) at (2,0.25);
+\coordinate (n3) at (3,0.25);
+\coordinate (n4) at (4,0.25);
+\coordinate (n5) at (5,0.25);
+\coordinate (n6) at (6,0.25);
+\coordinate (n7) at (7,0.25);
+\coordinate (n8) at (8,0.25);
+\coordinate (n9) at (9,0.25);
+\coordinate (n10) at (10,0.25);
+
+  \draw[color=black] (o1) to[] (o2) to[] (o3) to[] (o4) to (o5) to (o6) to (o7) to (o8) to (o9);
+  \draw[color=black] (o3) to[] (n4) to[] (n5) to[] (n6) to[] (n7);
+  \draw[color=black,thick, dotted, ->] (o9) to[] (o10);
+  \draw[color=black,thick, dotted, ->] (n7) to[] (n8);
+
+  %\filldraw[draw=black,fill=white] (o1) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o2) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o3) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o4) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o5) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o6) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o7) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o8) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o9) circle (5pt);
+  \node (rect) at (o1) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o2) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o3) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o4) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o5) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o6) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o7) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o8) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o9) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\filldraw[draw=black,fill=blue] (n4) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n5) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n6) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n7) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n8) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n9) circle (5pt);
+  %\node (rect) at (n1) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (n2) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (n3) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n4) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n5) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n6) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n7) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (n8) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (n9) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+\end{tikzpicture}
+    \\
+    &&\\
+    Hard fork &
+    \begin{tikzpicture}[domain=1:10,scale=0.35, every node/.style={scale=0.35}]
+\coordinate (o1) at (1,1);
+\coordinate (o2) at (2,1);
+\coordinate (o3) at (3,1);
+\coordinate (o4) at (4,1);
+\coordinate (o5) at (5,1);
+\coordinate (o6) at (6,1);
+\coordinate (o7) at (7,1);
+\coordinate (o8) at (8,1);
+\coordinate (o9) at (9,1);
+\coordinate (o10) at (10,1);
+\coordinate (n1) at (1,0.25);
+\coordinate (n2) at (2,0.25);
+\coordinate (n3) at (3,0.25);
+\coordinate (n4) at (4,0.25);
+\coordinate (n5) at (5,0.25);
+\coordinate (n6) at (6,0.25);
+\coordinate (n7) at (7,0.25);
+\coordinate (n8) at (8,0.25);
+\coordinate (n9) at (9,0.25);
+\coordinate (n10) at (10,0.25);
+
+  \draw[color=black] (o1) to[] (o2) to[] (o3) to[] (o4) to (o5) to (o6) to (o7);
+  \draw[color=black] (o3) to[] (n4) to[] (n5) to[] (n6) to[] (n7) to[] (n8) to[] (n9);
+  \draw[color=black,thick, dotted, ->] (o7) to[] (o8);
+  \draw[color=black,thick, dotted, ->] (n9) to[] (n10);
+
+  %\filldraw[draw=black,fill=white] (o1) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o2) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o3) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o4) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o5) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o6) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o7) circle (5pt);
+  \node (rect) at (o1) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o2) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o3) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o4) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o5) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o6) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o7) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (o8) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (o9) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\filldraw[draw=black,fill=white] (o8) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o9) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n4) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n5) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n6) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n7) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n8) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n9) circle (5pt);
+  %\node (rect) at (n1) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (n2) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (n3) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n4) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n5) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n6) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n7) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n8) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n9) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+\end{tikzpicture}
+  &
+\begin{tikzpicture}[domain=1:10,scale=0.35, every node/.style={scale=0.35}]
+\coordinate (o1) at (1,1);
+\coordinate (o2) at (2,1);
+\coordinate (o3) at (3,1);
+\coordinate (o4) at (4,1);
+\coordinate (o5) at (5,1);
+\coordinate (o6) at (6,1);
+\coordinate (o7) at (7,1);
+\coordinate (o8) at (8,1);
+\coordinate (o9) at (9,1);
+\coordinate (o10) at (10,1);
+\coordinate (n1) at (1,0.25);
+\coordinate (n2) at (2,0.25);
+\coordinate (n3) at (3,0.25);
+\coordinate (n4) at (4,0.25);
+\coordinate (n5) at (5,0.25);
+\coordinate (n6) at (6,0.25);
+\coordinate (n7) at (7,0.25);
+\coordinate (n8) at (8,0.25);
+\coordinate (n9) at (9,0.25);
+\coordinate (n10) at (10,0.25);
+
+  \draw[color=black] (o1) to[] (o2) to[] (o3) to[] (o4) to (o5) to (o6) to (o7) to (o8) to (o9);
+  \draw[color=black] (o3) to[] (n4);
+  \draw[color=black] (o6) to[] (n7);
+  \draw[color=black,thick, dotted, ->] (o9) to[] (o10);
+  %\draw[color=black, dashed] (n4) to[] (n5);
+  %\draw[color=black, dashed] (n7) to[] (n8);
+
+  %\filldraw[draw=black,fill=white] (o1) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o2) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o3) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o4) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o5) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o6) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o7) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o8) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o9) circle (5pt);
+  \node (rect) at (o1) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o2) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o3) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o4) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o5) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o6) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o7) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o8) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o9) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\filldraw[draw=black,fill=blue] (n4) circle (5pt);
+  \node (rect) at (n4) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\filldraw[draw=black,fill=blue] (n5) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n6) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n7) circle (5pt);
+  \node (rect) at (n7) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\filldraw[draw=black,fill=blue] (n8) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n9) circle (5pt);
+\end{tikzpicture}
+
+   \\
+    &&\\
+    Forced fork &
+    \begin{tikzpicture}[domain=1:10,scale=0.35, every node/.style={scale=0.35}]
+\coordinate (o1) at (1,1);
+\coordinate (o2) at (2,1);
+\coordinate (o3) at (3,1);
+\coordinate (o4) at (4,1);
+\coordinate (o5) at (5,1);
+\coordinate (o6) at (6,1);
+\coordinate (o7) at (7,1);
+\coordinate (o8) at (8,1);
+\coordinate (o9) at (9,1);
+\coordinate (o10) at (10,1);
+\coordinate (n1) at (1,0.25);
+\coordinate (n2) at (2,0.25);
+\coordinate (n3) at (3,0.25);
+\coordinate (n4) at (4,0.25);
+\coordinate (n5) at (5,0.25);
+\coordinate (n6) at (6,0.25);
+\coordinate (n7) at (7,0.25);
+\coordinate (n8) at (8,0.25);
+\coordinate (n9) at (9,0.25);
+\coordinate (n10) at (10,0.25);
+
+  \draw[color=black] (o1) to[] (o2) to[] (o3) to[] (o4) to (o5) to (o6) to (o7);
+  \draw[color=black] (o3) to[] (n4) to[] (n5) to[] (n6) to[] (n7) to[] (n8) to[] (n9);
+  \draw[color=black,thick, dotted, ->] (o7) to[] (o8);
+  \draw[color=black,thick, dotted, ->] (n9) to[] (n10);
+
+  %\filldraw[draw=black,fill=white] (o1) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o2) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o3) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o4) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o5) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o6) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o7) circle (5pt);
+  \node (rect) at (o1) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o2) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o3) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o4) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o5) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o6) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o7) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (o8) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (o9) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\filldraw[draw=black,fill=white] (o8) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o9) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n4) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n5) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n6) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n7) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n8) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n9) circle (5pt);
+  %\node (rect) at (n1) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (n2) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (n3) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n4) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n5) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n6) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n7) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n8) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n9) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+\end{tikzpicture}
+  &
+\begin{tikzpicture}[domain=1:10,scale=0.35, every node/.style={scale=0.35}]
+\coordinate (o1) at (1,1);
+\coordinate (o2) at (2,1);
+\coordinate (o3) at (3,1);
+\coordinate (o4) at (4,1);
+\coordinate (o5) at (5,1);
+\coordinate (o6) at (6,1);
+\coordinate (o7) at (7,1);
+\coordinate (o8) at (8,1);
+\coordinate (o9) at (9,1);
+\coordinate (o10) at (10,1);
+\coordinate (n1) at (1,0.25);
+\coordinate (n2) at (2,0.25);
+\coordinate (n3) at (3,0.25);
+\coordinate (n4) at (4,0.25);
+\coordinate (n5) at (5,0.25);
+\coordinate (n6) at (6,0.25);
+\coordinate (n7) at (7,0.25);
+\coordinate (n8) at (8,0.25);
+\coordinate (n9) at (9,0.25);
+\coordinate (n10) at (10,0.25);
+
+  \draw[color=black] (o1) to[] (o2) to[] (o3) to[] (o4) to (o5) to (o6) to (o7) to (o8) to (o9);
+  \draw[color=black] (o3) to[] (n4) to[] (n5) to[] (n6) to[] (n7);
+  \draw[color=black,thick, dotted, ->] (o9) to[] (o10);
+  \draw[color=black,thick, dotted, ->] (n7) to[] (n8);
+
+  %\filldraw[draw=black,fill=white] (o1) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o2) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o3) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o4) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o5) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o6) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o7) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o8) circle (5pt);
+  %\filldraw[draw=black,fill=white] (o9) circle (5pt);
+  \node (rect) at (o1) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o2) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o3) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o4) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o5) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o6) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o7) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o8) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (o9) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\filldraw[draw=black,fill=blue] (n4) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n5) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n6) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n7) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n8) circle (5pt);
+  %\filldraw[draw=black,fill=blue] (n9) circle (5pt);
+  %\node (rect) at (n1) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (n2) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (n3) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n4) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n5) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n6) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node (rect) at (n7) [fill=blue,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (n8) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  %\node (rect) at (n9) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+\end{tikzpicture}
+
+\\
+&&\\ \hline \hline
+  \end{tabular}
+\end{table}

--- a/assets/figures/hard-fork.tex
+++ b/assets/figures/hard-fork.tex
@@ -1,0 +1,6 @@
+%%% Figure from: Schär, Fabian. "Blockchain Forks: A Formal Classification Framework and Persistency Analysis." (2020).
+
+\begin{tikzpicture}[domain=0:8,scale=0.9, every node/.style={scale=1}]
+  \filldraw[draw=black,fill=blue!20] (0,0) circle (50pt) node[below=-1.15cm,color=black]{\footnotesize{$S_{new}$}};
+  \filldraw[draw=black,fill=white,dashed] (0.5,-0.4) circle (28pt) node[color=black]{\footnotesize{$S_{old}$}};
+\end{tikzpicture}

--- a/assets/figures/simple-block-sequence.tex
+++ b/assets/figures/simple-block-sequence.tex
@@ -1,0 +1,35 @@
+%%% Figure from: Schär, Fabian. "Blockchain Forks: A Formal Classification Framework and Persistency Analysis." (2020).
+
+\begin{tikzpicture}[domain=1:10,scale=1.3, every node/.style={scale=1.1}]
+\coordinate (o1) at (1,1);
+\coordinate (o2) at (2,1);
+\coordinate (o3) at (3,1);
+\coordinate (o4) at (4,1);
+\coordinate (o5) at (5,1);
+\coordinate (o6) at (6,1);
+\coordinate (o7) at (7,1);
+\coordinate (o8) at (8,1);
+\coordinate (o9) at (9,1);
+\coordinate (o10) at (10,1);
+\coordinate (n1) at (1,0.25);
+\coordinate (n2) at (2,0.25);
+\coordinate (n3) at (3,0.25);
+\coordinate (n4) at (4,0.25);
+\coordinate (n5) at (5,0.25);
+\coordinate (n6) at (6,0.25);
+\coordinate (n7) at (7,0.25);
+\coordinate (n8) at (8,0.25);
+\coordinate (n9) at (9,0.25);
+\coordinate (n10) at (10,0.25);
+
+  \draw[color=black] (o1) to[] (o2) to[] (o3) to[] (o4);
+  \draw[color=black,thick, dotted, ->] (o4) to[] (o5);
+  \node (rect) at (o1) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node at (o1) [minimum width=1cm,minimum height=1cm,above] {${b}_0$};
+  \node (rect) at (o2) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node at (o2) [minimum width=1cm,minimum height=1cm,above] {${b}_1$};
+  \node (rect) at (o3) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node at (o3) [minimum width=1cm,minimum height=1cm,above] {${b}_2$};
+  \node (rect) at (o4) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node at (o4) [minimum width=1cm,minimum height=1cm,above] {${b}_3$};
+\end{tikzpicture}

--- a/assets/figures/simple-fork.tex
+++ b/assets/figures/simple-fork.tex
@@ -1,0 +1,40 @@
+%%% Figure from: Schär, Fabian. "Blockchain Forks: A Formal Classification Framework and Persistency Analysis." (2020).
+
+\begin{tikzpicture}[domain=1:10,scale=1.3, every node/.style={scale=1.1}]
+\coordinate (o1) at (1,1);
+\coordinate (o2) at (2,1);
+\coordinate (o3) at (3,1);
+\coordinate (o4) at (4,1);
+\coordinate (o5) at (5,1);
+\coordinate (o6) at (6,1);
+\coordinate (o7) at (7,1);
+\coordinate (o8) at (8,1);
+\coordinate (o9) at (9,1);
+\coordinate (o10) at (10,1);
+\coordinate (n1) at (1,0.25);
+\coordinate (n2) at (2,0.25);
+\coordinate (n3) at (3,0.25);
+\coordinate (n4) at (4,0.25);
+\coordinate (n5) at (5,0.25);
+\coordinate (n6) at (6,0.25);
+\coordinate (n7) at (7,0.25);
+\coordinate (n8) at (8,0.25);
+\coordinate (n9) at (9,0.25);
+\coordinate (n10) at (10,0.25);
+
+  \draw[color=black] (o1) to[] (o2) to[] (o3) to[] (o4);
+  \draw[color=black,thick, dotted, ->] (o4) to[] (o5);
+    \draw[color=black] (o3) to[] (n4);
+  \draw[color=black,thick, dotted, ->] (n4) to[] (n5);
+  \node (rect) at (o1) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node at (o1) [minimum width=1cm,minimum height=1cm,above] {${b}_0$};
+  \node (rect) at (o2) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node at (o2) [minimum width=1cm,minimum height=1cm,above] {${b}_1$};
+  \node (rect) at (o3) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node at (o3) [minimum width=1cm,minimum height=1cm,above] {${b}_2$};
+  \node (rect) at (o4) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node at (o4) [minimum width=1cm,minimum height=1cm,above] {${b}_3$};
+    \node (rect) at (n4) [fill=white,draw,minimum width=0.3cm,minimum height=0.3cm] {};
+  \node at (n4) [minimum width=1cm,minimum height=1cm,below] {${b}_{3a}$};
+
+\end{tikzpicture}

--- a/assets/figures/soft-fork.tex
+++ b/assets/figures/soft-fork.tex
@@ -1,0 +1,6 @@
+%%% Figure from: Schär, Fabian. "Blockchain Forks: A Formal Classification Framework and Persistency Analysis." (2020).
+
+\begin{tikzpicture}[domain=0:8,scale=0.9, every node/.style={scale=1}]
+  \filldraw[draw=black,fill=white] (0,0) circle (50pt) node[below=-1.15cm,color=black]{\footnotesize{$S_{old}$}};
+  \filldraw[draw=black,fill=blue!20,dashed] (0.5,-0.4) circle (28pt) node[color=black]{\footnotesize{$S_{new}$}};
+\end{tikzpicture}

--- a/slides/bitcoin-primer.tex
+++ b/slides/bitcoin-primer.tex
@@ -29,7 +29,7 @@ Some key aspects of Bitcoin: \vspace{1em}
 		\item<4-> Decentralized management
 	\end{enumerate}
 	\vspace{1em}	
-\uncover<5->{Bitcoin is a decentralized data structure.} \\	\vspace{1em}
+\uncover<5->{Bitcoin is a decentralized data structure and information protocol.} \\	\vspace{1em}
 \uncover<6->{The system is maintained by its participants and works in the absence of centralized third parties.} 
 \end{frame}
 %%%	
@@ -100,7 +100,7 @@ This approach ensures transaction \color{focus}authenticity \color{black}and \co
 \begin{frame}{Transaction Consensus}
 \textbf{Goal: }Deciding which (legitimate) transactions are valid. \\
 \vspace{1em}
-Double spend problem: \\
+Double-Spending: \\
 \begin{figure}[h!]
 	\center
 	\input{../assets/figures/double-spend.tex}

--- a/slides/bitcoin-primer.tex
+++ b/slides/bitcoin-primer.tex
@@ -52,7 +52,7 @@ Because of the decentralized infrastructure, the transaction \textbf{capacity}, 
 
 %%%
 \begin{frame}{Transaction Capacity}
-\textbf{Goal:} ensuring the ability to initiate a transaction  \\
+\textbf{Goal:} Ensuring the ability to initiate a transaction.  \\
 	\begin{figure}[h!]
 		\center
 		\input{../assets/figures/transaction-capacity.tex}
@@ -76,7 +76,7 @@ Because of the decentralized infrastructure, the transaction \textbf{capacity}, 
 	\begin{figure}[h!]
 		\center
 		\input{../assets/figures/transaction-encryption.tex}
-		\caption{Encryption and decryption of the transaction message.}
+		\caption*{Encryption and decryption of the transaction message}
 		\label{fig:asymmeinfach}
 	\end{figure}
 \end{frame}
@@ -110,10 +110,10 @@ Double-Spending: \\
 
 %%%
 \begin{frame}{Blocks and the Blockchain}
-Transactions are bundled into blocks \\
+Transactions are bundled into blocks. \\
 \includegraphics[width=6cm]{../assets/images/block_1.png} \\
 \uncover<2->{
-Blocks are sequentially linked $\rightarrow $ blockchain \\
+Blocks are sequentially linked $\rightarrow $ Blockchain \\
 \includegraphics[width=6cm]{../assets/images/blocks_3.png}
 } 
 \end{frame}
@@ -125,6 +125,7 @@ Blocks are sequentially linked $\rightarrow $ blockchain \\
 	\center
 	\input{../assets/figures/blockchain-example.tex}
 \end{figure}
+\vspace{1em}
 \begin{itemize}
 \item{Change in a block component results in a change in the identification number.}
 \item{If an earlier block content is changed, this leads to inconsistency in the chain structure.}
@@ -138,15 +139,18 @@ Blocks are sequentially linked $\rightarrow $ blockchain \\
 Network participants, who decide to allocate computing power in order to create new blocks are called Bitcoin Miners.
 \center
 \includegraphics[width=6cm]{../assets/images/miner.png}
-
-\begin{itemize}
-\item{Miner chooses the status quo on which to base its block (most recent version of Blockchain)}
-\item{Miner chooses a subset of the transactions from its queue (mempool) to create a block, as long as they...}
+\uncover<2->{
 	\begin{itemize}
-	\item{\dots are legitimate}
-	\item{\dots do not conflict with other transactions}
-	\item{\dots do not exceed block size limitation}
+	\item{Miner chooses the status quo on which to base its block. (Most recent version of Blockchain)}
+}
+\uncover<3->{
+	\item{Miner chooses a subset of the transactions from its queue (mempool) to create a block, as long as they...}
+	\begin{itemize}
+		\item{\dots are legitimate.}
+		\item{\dots do not conflict with other transactions.}
+		\item{\dots do not exceed block size limitation.}
 	\end{itemize}
+	}
 \end{itemize}
 \end{frame}
 %%%
@@ -179,7 +183,7 @@ How to reach consensus?: \\
 %%%
 
 %%%
-\begin{frame}{References and Recommended Reading}
+\begin{frame}{Recommended Reading}
 \begin{columns}
 	\begin{column}{0.3\textwidth}
 	\center

--- a/slides/fork_theory.tex
+++ b/slides/fork_theory.tex
@@ -115,7 +115,7 @@ Example: Upgrade to Bitcoin client 0.8 in 2013
 \vspace{0.5em}
 
 Example: Split of Bitcoin ABC over Blocksize increase.
-\vspace{1em}	
+\vspace{2em}	
 	
 }
 
@@ -184,11 +184,22 @@ $\Rightarrow$ Not resolved automatically and may cause permanent splits.
 %%%
 \begin{frame}{Fork Persistency by Type and Dominance Scenario}
 
+\center \footnotesize
+$P(\,b \in S_{new} \wedge b \in S_{old})\, = \dfrac{r_{old}}{R} \left( 1-\frac{|S_{new} \cap S_{old}|}{|S_{old}|}\right) + \dfrac{r_{new}}{R} \left( 1-\frac{|S_{new} \cap S_{old}|}{|S_{new}|}\right)$ 
+\label{eq:forkprobability}
+
+\vspace{1.5em}
+
+
 	\begin{table}
 		\input{../assets/figures/fork-types.tex}
 		\caption{Persistency by fork type and scenario \cite{schar2020blockchain}}
 		\label{tbl:forkpersistencies}
 	\end{table}
+
+	
+
+
 	
 \end{frame}
 %%%

--- a/slides/fork_theory.tex
+++ b/slides/fork_theory.tex
@@ -1,0 +1,229 @@
+% Choose one to switch between slides and handout
+%\documentclass[]{beamer}
+\documentclass[handout]{beamer}
+
+% Video Meta Data
+\title{Bitcoin, Blockchain and Cryptoassets}
+\subtitle{Transaction Consensus: Fork Theory}
+\author{Prof. Dr. Fabian Schär}
+\institute{University of Basel}
+
+% Config File
+\input{../config/config.tex}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\begin{document}
+
+\thispagestyle{empty}
+\begin{frame}[noframenumbering]
+	\titlepage
+\end{frame}
+
+%%%
+
+%%%
+\begin{frame}{What is a Fork?}
+
+\color{focus} Disagreement on the current state \color{black} of the ledger that, if persisting, leads to a \color{focus} split of the network \color{black}  into two or more competing database instances
+
+\begin{columns}[T]
+	\begin{column}{0.45\textwidth}
+		\begin{figure}[h]
+  			\center
+  			\resizebox{0.9\textwidth}{!}{
+			\input{../assets/figures/simple-block-sequence.tex}
+			}
+		\end{figure}
+	\end{column}
+	\begin{column}{0.45\textwidth}
+		\begin{figure}[h]
+  			\center
+  			\resizebox{0.9\textwidth}{!}{
+			\input{../assets/figures/simple-fork.tex}
+			}
+		\end{figure}
+	\end{column}
+\end{columns}
+
+\begin{columns}[T]
+	\begin{column}{0.45\textwidth}
+		\center		
+		\footnotesize Simple Block Sequence
+	\end{column}
+	\begin{column}{0.45\textwidth}
+		\center
+ 		\footnotesize Simple Fork 
+	\end{column}
+\end{columns}
+\begin{center}
+Figure: Illustration Blockchain Fork \cite{schar2020blockchain}
+\end{center}
+
+\uncover<2->{
+\vspace{1em}	
+$\Rightarrow$ Unique characteristic of Blockchains, not conclusively defined.
+}
+
+\end{frame}
+%%%
+
+%%%
+\begin{frame}{Classification of Forks}
+
+Placeholder: Missing Classification table 
+	
+\end{frame}
+%%%	
+
+%%%
+\begin{frame}{Process-based Forks}
+
+\textbf{Probabilistic block race:} Unintentionally coexisting consensus versions, caused by network propagation delays. 
+\vspace{1em}	
+
+\uncover<2->{
+\textbf{Forced block race:} Deliberate mining of own chain with the goal to overtake consensus version.
+\vspace{1em}	
+
+
+\textbf{Block withholding:} Purposeful delay of propagation of own valid block candidate to gain head start on next block.
+\vspace{1em}	
+}
+
+\uncover<3->{
+$\Rightarrow$ All temporary and resolved through accumulated difficulty.
+}
+	
+\end{frame}
+%%%
+
+%%%
+\begin{frame}{Protocol-based forks}
+
+\textbf{Client incompatibility:} Delta in consensus rule implementations by different network client software, causing some nodes to accept certain blocks rejected by others. Root causes:
+\begin{itemize}
+	\item Loosely defined consensus rules
+	\item Software bugs
+\end{itemize}
+\vspace{0.5em}
+Example: Upgrade to Bitcoin client 0.8 in 2013
+\vspace{1em}	
+
+\uncover<2->{
+\textbf{Rule change:} Part of the network decides to alter the consensus rule set $S$ and proceed with adapted protocol.
+\vspace{0.5em}
+
+Example: Split of Bitcoin ABC over Blocksize increase.
+\vspace{1em}	
+	
+}
+
+\uncover<3->{
+$\Rightarrow$ Not resolved automatically and may cause permanent splits.
+}
+	
+\end{frame}
+%%%
+
+%%%
+\begin{frame}{Types of Protocol-based Forks}
+
+
+\begin{columns}[T]
+	\begin{column}{0.3\textwidth}
+		\center		
+		\textbf{Soft Fork}\\
+		\vspace{0.5em}
+		\begin{figure}[h]
+  			\resizebox{0.9\textwidth}{!}{
+			\input{../assets/figures/soft-fork.tex}
+			}
+		\end{figure}
+		\vspace{1em}
+		$S_{new}\subset S_{old}$
+	\end{column}
+	\begin{column}{0.3\textwidth}
+		\center
+ 		\textbf{Hard Fork}\\
+ 		\vspace{1em}
+ 		\begin{figure}[h]
+  			\center
+  			\resizebox{0.9\textwidth}{!}{
+			\input{../assets/figures/hard-fork.tex}
+			}
+		\end{figure}
+ 		\vspace{1.5em}
+ 		$S_{new}\supset S_{old}$
+	\end{column}
+		\begin{column}{0.3\textwidth}
+		\center
+ 		\textbf{Forced Fork}\\
+ 		\vspace{0.5em}
+ 		\begin{figure}[h]
+  			\center
+  			\resizebox{0.9\textwidth}{!}{
+			\input{../assets/figures/forced-fork.tex}
+			}
+		\end{figure}
+		\vspace{0.8em}
+ 		$(S_{new}\setminus S_{old} \neq \emptyset)$\\$\wedge$\\ $(S_{old}\setminus S_{new} \neq \emptyset)$
+	\end{column}
+\end{columns}
+
+\vspace{0.5em}
+
+\begin{center}
+	Figure: Types of protocol-based forks \cite{schar2020blockchain}
+\end{center}
+
+	
+\end{frame}
+%%%
+
+%%%
+\begin{frame}{Fork Persistency by Type and Dominance Scenario}
+
+	\begin{table}
+		\input{../assets/figures/fork-types.tex}
+		\caption{Persistency by fork type and scenario \cite{schar2020blockchain}}
+		\label{tbl:forkpersistencies}
+	\end{table}
+	
+\end{frame}
+%%%
+
+
+
+%%%
+\begin{frame}{Why Care about Forks?}
+
+\textbf{Uncertainty:} Confirmation status of transactions.
+\vspace{1.5em}
+
+\textbf{Confusion:} Which one is the "main" version.
+\vspace{1.5em}
+
+\textbf{Undermining trust:} Case of digital assets.
+\vspace{1.5em}
+
+\textbf{Cost driver:} Maintaining compatibility.
+\vspace{1.5em}
+
+\color{focus} \textbf{But:} \color{black} Pillar for political freedom and resilience against arbitrary changes.
+
+	
+\end{frame}
+%%%	
+
+%%%
+\begin{frame}%[allowframebreaks]
+\frametitle{References and Recommended Reading}
+
+	\bibliographystyle{amsplain}
+	\bibliography{../assets/bib/refs}
+
+\end{frame}
+
+
+\end{document}

--- a/slides/fork_theory.tex
+++ b/slides/fork_theory.tex
@@ -97,15 +97,15 @@ $\Rightarrow$ Unique characteristic of Blockchains, not conclusively defined.
 \begin{frame}{Process-based Forks}
 
 \textbf{Probabilistic block race:} Unintentionally coexisting consensus versions, caused by network propagation delays. 
-\vspace{1em}	
+\vspace{1.5em}	
 
 \uncover<2->{
 \textbf{Forced block race:} Deliberate mining of own chain with the goal to overtake consensus version.
-\vspace{1em}	
+\vspace{1.5em}	
 
 
 \textbf{Block withholding:} Purposeful delay of propagation of own valid block candidate to gain head start on next block.
-\vspace{1em}	
+\vspace{1.5em}	
 }
 
 \uncover<3->{

--- a/slides/fork_theory.tex
+++ b/slides/fork_theory.tex
@@ -70,12 +70,14 @@ $\Rightarrow$ Unique characteristic of Blockchains, not conclusively defined.
 
 %%%
 \begin{frame}{Classification of Forks}
+
 \footnotesize
 \begin{table}
   \center
   \begin{tabular}[]{rll}
     \hline\hline 
-    ~                      & \textbf{Process-based ($A=B=S$)} & \textbf{Protocol-based $(A \neq B)$}      \\ \cline{2-3} 
+    ~	& \textbf{Process-based} & \textbf{Protocol-based}      \\
+    ~	& $(A=B=S)$ & $(A \neq B)$ \\\cline{2-3} 
     \rule{0pt}{3ex}    
     \textbf{Unintentional} & Probabilistic Block Race & Client Incompatibility \\ 
         &  & \makecell[l]{\hspace{1em}\textbullet{ }\footnotesize{Soft Fork} \\   \hspace{1em}\textbullet{ }\footnotesize{Hard Fork} \\  \hspace{1em}\textbullet{ }\footnotesize{Forced Fork} }   \\
@@ -87,7 +89,6 @@ $\Rightarrow$ Unique characteristic of Blockchains, not conclusively defined.
   \caption{The four fork types \cite{schar2020blockchain}}
   \label{tbl:classification}
 \end{table}
-%%%
 	
 \end{frame}
 %%%	
@@ -234,7 +235,7 @@ $P(\,b \in S_{new} \wedge b \in S_{old})\, = \dfrac{r_{old}}{R} \left( 1-\frac{|
 \textbf{Undermining trust:} Case of digital assets.
 \vspace{1.5em}
 
-\textbf{Cost driver:} Maintaining compatibility.
+\textbf{Cost driver:} Tax / legal questions, maintaining compatibility.
 \vspace{1.5em}
 
 \color{focus} \textbf{But:} \color{black} Pillar for political freedom and resilience against arbitrary changes.


### PR DESCRIPTION
Addition of first version of tex file for lecture "Transaction Consensus: Fork Theory" including the respective images used and tables created.
Known issue: 
* Equation on Slide 6 not yet formatted as proper equation. Space problem with current slide size.
* Team slide yet missing
No config changes, no new packages


## Type of Change

- [x ] Major feature (New files or assets, large changes to files)

# Checklist:

- [x] I have performed a self-review of my own changes
- [x] I have made sure that any changed LaTeX files compile properly
- [x] I have assigned at least one reviewer
