### PR TITLE
FIx asymm crypto applications figure

### DIFF
--- a/assets/figures/publickeycrypto_applications.tex
+++ b/assets/figures/publickeycrypto_applications.tex
@@ -8,8 +8,8 @@
 
 
 
-\draw[<-,thick] (-0.25,3) -- (4.25,3) node[above, midway] {\footnotesize{Encrypt/Hide}};
-\draw[<-,thick] (5.75,3) -- (10.25,3) node[above, midway] {\footnotesize{Decrypt/Read}};
+\draw[<-,thick] (-0.25,3) -- (4.25,3) node[above, midway] {\footnotesize{Decrypt/Read}};
+\draw[<-,thick] (5.75,3) -- (10.25,3) node[above, midway] {\footnotesize{Encrypt/Hide}};
 
 \draw[->,thick] (-0.25,1) -- (4.25,1) node[below, midway] {\footnotesize{Encrypt/Sign}} ;
 \draw[->,thick] (5.75,1) -- (10.25,1) node[below, midway] {\footnotesize{Decrypt/Verify}} ;


### PR DESCRIPTION
# Description
Fixes typo in upper row of crypto applications slide. Note that asymm crypto and bitcoin primer slide decks have been affected.

## Type of Change
- [X] Typo fix (Changes that fix spelling errors)

# Checklist:

- [X] I have performed a self-review of my own changes
- [X] I have made sure that any changed LaTeX files compile properly
- [X] I have assigned at least one reviewer
